### PR TITLE
Patch in prometheus scrape annotation

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-upstream manifests: https://github.com/kubernetes/kube-state-metrics/tree/master/examples/standard

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# kube-state-metrics-manifests
+
+A Kustomize base for deploying
+[kube-state-metrics](https://github.com/kubernetes/kube-state-metrics).
+
+## Updating
+
+Copy files from the
+[upstream](https://github.com/kubernetes/kube-state-metrics/tree/master/examples/standard),
+splitting cluster-scoped and namespaced-scoped resources into `cluster/` and `namespaced/`
+respectively.
+
+Patches to the upstream manifests can be found in
+`{cluster,namespaced}/patch.yaml`. Amend these in response to any relevant
+upstream changes.

--- a/namespaced/kustomization.yaml
+++ b/namespaced/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - deployment.yaml
   - service-account.yaml
   - service.yaml
+patchesStrategicMerge:
+  - patch.yaml

--- a/namespaced/patch.yaml
+++ b/namespaced/patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+spec:
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"


### PR DESCRIPTION
Inadvertently removed this when updating from the upstream. I think putting any changes we're making in a patch file is better because it highlights what is 'vendored' and what we're changing on top.