### PR TITLE
Add labels to allowlist

### DIFF
--- a/namespaced/patch.yaml
+++ b/namespaced/patch.yaml
@@ -7,3 +7,8 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
+    spec:
+      containers:
+        - name: kube-state-metrics
+          args:
+            - --metric-labels-allowlist=namespaces=[uw.systems/owner],pods=[app,app.kubernetes.io/name]


### PR DESCRIPTION
From 2.0.0 onwards you need to explicitly define the labels you want to export for the given resource types. I'm including the ones I can find evidence of us using.